### PR TITLE
chore: upgrade to deno 1.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: denolib/setup-deno@v2
+      - uses: denoland/setup-deno@main
         with:
-          deno-version: v1.8
+          deno-version: "~1.9"
       - uses: actions/cache@v2
         with:
           path: ~/.cache/deno        # see https://deno.land/manual/linking_to_external_code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: denolib/setup-deno@v2
+      - uses: denoland/setup-deno@main
         with:
-          deno-version: v1.8
+          deno-version: "~1.9"
       - uses: actions/cache@v2
         with:
           path: ~/.cache/deno # see https://deno.land/manual/linking_to_external_code


### PR DESCRIPTION
also use official deno-setup github action, replacing the inofficial one
https://github.com/denolib/setup-deno/pull/83