### PR TITLE
refactor(cli): use cliffy.io instead of commander

### DIFF
--- a/test/list.sh
+++ b/test/list.sh
@@ -37,7 +37,7 @@ it_can_list_with_unknown_profile() {
   
   out=$(unipipe list --profile xx "$repo_osb" 2>&1) || true
   
-  assert_eq "Unrecognized --profile: xx" "$out" "expected error"
+  assert_eq 'Illegal option --profile: must be one of ["meshmarketplace", "cloudfoundry"] but got "xx".' "$out" "expected error"
 }
 
 it_can_list_with_output_json() {

--- a/unipipe/commands/helpers.ts
+++ b/unipipe/commands/helpers.ts
@@ -1,5 +1,30 @@
-import { path } from '../deps.ts';
+import { ITypeInfo, path, Type } from '../deps.ts';
 import { readInstance, ServiceInstance } from '../osb.ts';
+
+// TODO it would be nice to generate help text for allowed enum values
+export class EnumType extends Type<string> {
+  
+  constructor(private readonly allowed: readonly string[]){
+    super();
+}
+
+  public parse({ label, name, value }: ITypeInfo): string {
+    if (!this.allowed.includes(value)) {
+      const legal = this.allowed.map(x => `"${x}"`).join(", ");
+
+      console.error(
+        `Illegal ${label.toLowerCase()} ${name}: must be one of [${legal}] but got "${value}".`,
+      );
+      Deno.exit(1)
+    }
+
+    return value;
+  }
+
+  public complete(): string[] {
+    return this.allowed.slice();
+  }
+}
 
 /**
  * A helper function to implement commands that need to perform a map operation on instances.

--- a/unipipe/commands/list.ts
+++ b/unipipe/commands/list.ts
@@ -1,13 +1,109 @@
-import { table } from '../deps.ts';
-import { mapInstances } from './helpers.ts';
+// import { Table } from '../deps.ts';
+import { Command, Table } from '../deps.ts';
+import { MeshMarketplaceContext } from '../mesh.ts';
+import { CloudFoundryContext, OsbServiceInstance } from '../osb.ts';
+import { EnumType, mapInstances } from './helpers.ts';
 
-export interface ListOpts {
-  osbRepoPath: string;
-  profile?: string;
-  format: string;
+// see https://stackoverflow.com/questions/44480644/string-union-to-string-array for the trick used here
+const ALL_FORMATS = ["text", "json"] as const;
+type FormatsTuple = typeof ALL_FORMATS;
+type Format = FormatsTuple[number];
+
+const formatsType = new EnumType(ALL_FORMATS);
+
+const ALL_PROFILES = ["meshmarketplace", "cloudfoundry"] as const;
+type ProfilesTuple = typeof ALL_PROFILES;
+type Profile = ProfilesTuple[number];
+
+const profilesType = new EnumType(ALL_PROFILES);
+
+interface ListOpts {
+  profile?: Profile;
+  outputFormat: Format;
 }
 
-function profileCols(profile?: string): string[] {
+export function registerListCmd(program: Command) {
+  program
+    .command("list <repo>")
+    .type("format", formatsType)
+    .type("profile", profilesType)
+    .option(
+      "-p, --profile [profile:profile]",
+      "include columns of context information according to the specified OSB API profile. Supported values are 'meshmarketplace' and 'cloudfoundry'. Ignored when '-o json' is set.",
+    )
+    .option(
+      "-o, --output-format [format:format]",
+      "Output format. Supported formats are json and text.",
+      {
+        default: "text",
+      },
+    )
+    .description(
+      "Lists service instances status stored in a UniPipe OSB git repo.",
+    )
+    .action(async (options: ListOpts, repo: string) => {
+      await list(repo, options);
+    });
+}
+
+export async function list(osbRepoPath: string, opts: ListOpts) {
+  switch (opts.outputFormat) {
+    case "json":
+      await listJson(osbRepoPath);
+      break;
+    case "text":
+      await listTable(osbRepoPath, opts.profile);
+      break;
+  }
+}
+
+async function listJson(osbRepoPath: string) {
+  const results = await mapInstances(
+    osbRepoPath,
+    async (instance) => await instance,
+  );
+  console.log(JSON.stringify(results));
+}
+
+async function listTable(osbRepoPath: string, profile?: Profile) {
+  const results = await mapInstances(osbRepoPath, async (instance) => {
+    const i = instance.instance;
+
+    const plan = i.serviceDefinition.plans.filter((x) => x.id === i.planId)[0];
+
+    const pcols: string[] = profileColValues(i, profile);
+
+    return await [
+      i.serviceInstanceId,
+      ...pcols,
+      plan?.name || "",
+      i.serviceDefinition.name,
+      instance.status?.status || "",
+      i.deleted === undefined ? "" : i.deleted.toString(),
+    ];
+  });
+
+  const pcols = profileColHeaders(profile);
+  const header = [
+    "id",
+    ...pcols,
+    "service",
+    "plan",
+    "status",
+    "deleted",
+  ];
+
+  new Table()
+    .header(header)
+    .body(results)
+    .render();
+
+  console.log(
+    // table(results, ),
+  );
+}
+
+function profileColHeaders(profile?: Profile): string[] {
   switch (profile) {
     case undefined:
       return [];
@@ -15,65 +111,29 @@ function profileCols(profile?: string): string[] {
       return ["customer", "project"];
     case "cloudfoundry":
       return ["organization", "space"];
-    default:
-      console.error("Unrecognized --profile: " + profile);
-      Deno.exit(1);
   }
 }
 
-export async function list(opts: ListOpts) {
-  switch (opts.format) {
-    case "json":
-      await listJson(opts);
-      break;
-    case "text":
-      await listTable(opts);
-      break;
-    default:
-      console.error("Unrecognized --output-format: " + opts.format);
-      Deno.exit(1);
+function profileColValues(
+  i: OsbServiceInstance,
+  profile?: Profile,
+): string[] {
+  switch (profile) {
+    case undefined:
+      return [];
+    case "meshmarketplace": {
+      const ctx = i.context as MeshMarketplaceContext;
+      return [
+        ctx.customer_id,
+        ctx.project_id,
+      ];
+    }
+    case "cloudfoundry": {
+      const ctx = i.context as CloudFoundryContext;
+      return [
+        ctx.organization_name,
+        ctx.space_name,
+      ];
+    }
   }
-}
-
-async function listJson(opts: ListOpts) {
-  const results = await mapInstances(opts.osbRepoPath, async(instance) => await instance);
-  console.log(JSON.stringify(results));
-}
-
-async function listTable(opts: ListOpts) {
-  const pcols = profileCols(opts.profile);
-
-  const results = await mapInstances(opts.osbRepoPath, async (instance) => {
-    const i = instance.instance;
-
-    const plan = i.serviceDefinition.plans.filter((x) => x.id === i.planId)[0];
-
-    return await {
-      id: i.serviceInstanceId,
-
-      // meshmarketplace context
-      customer: i.context.customer_id,
-      project: i.context.project_id,
-
-      // cloudfoundry context object, https://github.com/openservicebrokerapi/servicebroker/blob/master/profile.md#cloud-foundry-context-object
-      organization: i.context.organization_name,
-      space: i.context.space_name,
-
-      plan: plan?.name,
-      service: i.serviceDefinition.name,
-      status: instance.status?.status,
-      deleted: i.deleted,
-    };
-  });
-
-  console.log(
-    table(results, [
-      "id",
-      ...pcols,
-      "service",
-      "plan",
-      "status",
-      "deleted",
-    ]),
-  );
 }

--- a/unipipe/commands/transform.ts
+++ b/unipipe/commands/transform.ts
@@ -1,12 +1,59 @@
+import { Command } from '../deps.ts';
 import { write } from '../dir.ts';
 import { InstanceHandler } from '../handler.ts';
 import { ServiceInstance } from '../osb.ts';
 import { mapInstances } from './helpers.ts';
 
-export interface TransformOpts {
-  osbRepoPath: string;
-  outRepoPath: string;
+interface TransformOpts {
+  xportRepo: string;
   handlers: string;
+}
+
+export function registerTransformCmd(program: Command) {
+  program
+    .command(
+      "transform <repo>",
+    )
+    .description(
+      "Transform service instances stored in a UniPipe OSB git repo using the specified handlers.",
+    )
+    .option(
+      "-h, --handlers <file>",
+      "A registry of handlers for processing service instance transformation. These can be defined in either javascript or typescript as a JSON object with service ids as keys and handler objects as values. Note: typescript registries are not supported in single-binary builds of unipipe-cli.",
+    )
+    .option(
+      "-x, --xport-repo [path:string]",
+      "Path to the target git repository. If not specified the transform runs in place on the OSB git repo.",
+    )
+    .action(async (options: TransformOpts, repo: string) => {
+      await transform(repo, options);
+    });
+}
+
+async function transform(
+  osbRepoPath: string,
+  opts: TransformOpts,
+) {
+  const handlers = await loadHandlers(opts.handlers);
+  const outRepoPath = opts.xportRepo || osbRepoPath;
+
+  mapInstances(osbRepoPath, async (instance: ServiceInstance) => {
+    const handler = handlers[instance.instance.serviceDefinitionId];
+    const handledBy = (handler && handler.name) || "(ho handler found)";
+
+    console.log(
+      `- instance id: ${instance.instance.serviceInstanceId} | definition id: ${instance.instance.serviceDefinitionId} -> ${handledBy}`,
+    );
+
+    if (!handler) {
+      return;
+    }
+
+    const tree = handler.handle(instance);
+    if (tree) {
+      await write(tree, outRepoPath);
+    }
+  });
 }
 
 async function loadHandlers(
@@ -37,27 +84,4 @@ async function loadHandlers(
       "could not land handlers, unsupport handler type (needs to be a '.ts' or '.js' file).",
     );
   }
-}
-export async function transform(
-  opts: TransformOpts,
-) {
-  const handlers = await loadHandlers(opts.handlers);
-
-  mapInstances(opts.osbRepoPath, async (instance: ServiceInstance) => {
-    const handler = handlers[instance.instance.serviceDefinitionId];
-    const handledBy = (handler && handler.name) || "(ho handler found)";
-
-    console.log(
-      `- instance id: ${instance.instance.serviceInstanceId} | definition id: ${instance.instance.serviceDefinitionId} -> ${handledBy}`,
-    );
-
-    if (!handler) {
-      return;
-    }
-
-    const tree = handler.handle(instance);
-    if (tree) {
-      await write(tree, opts.outRepoPath);
-    }
-  });
 }

--- a/unipipe/commands/update.ts
+++ b/unipipe/commands/update.ts
@@ -1,16 +1,49 @@
-import { path } from "../deps.ts";
-import { stringify } from "../yaml.ts";
+import { Command, path } from '../deps.ts';
+import { stringify } from '../yaml.ts';
+import { EnumType } from './helpers.ts';
 
-export interface UpdateOpts {
-  osbRepoPath: string;
+const ALL_STATUSES = ["succeeded", "failed", "in progress"] as const;
+type StatusesTuple = typeof ALL_STATUSES;
+type Status = StatusesTuple[number];
+
+const statusesType = new EnumType(ALL_STATUSES);
+
+interface UpdateOpts {
   instanceId: string;
-  status: "succeeded" | "failed" | "in progress";
-  description?: string;
+  status: Status;
+  description: string;
 }
 
-export async function update(opts: UpdateOpts) {
+export function registerUpdateCmd(program: Command) {
+  program
+    .command("update <repo>")
+    .type("status", statusesType)
+    .description(
+      "update status of a service instance stored in a UniPipe OSB git repo.",
+    )
+    .option(
+      "-i --instance-id <instance-id>",
+      "Service instance id.",
+    )
+    .option(
+      "--status <status:status>",
+      "The status. Allowed values are 'in progress', 'succeeded' and 'failed'.",
+    ) // todo use choices instead
+    .option(
+      "--description [description]",
+      "Service Instance status description text.",
+      {
+        default: "",
+      },
+    )
+    .action(async (options: UpdateOpts, repo: string) => {
+      await update(repo, options);
+    });
+}
+
+async function update(osbRepoPath: string, opts: UpdateOpts) {
   const statusYmlPath = path.join(
-    opts.osbRepoPath,
+    osbRepoPath,
     "instances",
     opts.instanceId,
     "status.yml",

--- a/unipipe/deps.ts
+++ b/unipipe/deps.ts
@@ -12,5 +12,10 @@ export { Type as YamlType } from "https://deno.land/std@0.90.0/encoding/_yaml/ty
 export { Schema as YamlSchema } from "https://deno.land/std@0.90.0/encoding/_yaml/schema.ts";
 
 // 3rd party deps
-export { Command } from "https://deno.land/x/cmd@v1.2.0/mod.ts";
-export { table } from "https://deno.land/x/minitable@v1.0/mod.ts";
+export {
+  Command,
+  Type,
+  CompletionsCommand
+} from "https://deno.land/x/cliffy@v0.18.2/command/mod.ts";
+export type { ITypeInfo } from "https://deno.land/x/cliffy@v0.18.2/command/mod.ts";
+export { Table } from "https://deno.land/x/cliffy@v0.18.2/table/mod.ts";

--- a/unipipe/main.ts
+++ b/unipipe/main.ts
@@ -1,121 +1,22 @@
-import { list, ListOpts } from './commands/list.ts';
-import { show, ShowOpts } from './commands/show.ts';
-import { transform, TransformOpts } from './commands/transform.ts';
-import { update, UpdateOpts } from './commands/update.ts';
-import { Command } from './deps.ts';
+import { registerListCmd } from './commands/list.ts';
+import { registerShowCmd } from './commands/show.ts';
+import { registerTransformCmd } from './commands/transform.ts';
+import { registerUpdateCmd } from './commands/update.ts';
+import { Command, CompletionsCommand } from './deps.ts';
 
-const program = new Command("UniPipe CLI");
-program.version("0.2.0");
-program.description("Supercharge your GitOps OSB service pipelines");
+const program = new Command()
+  .name("unipipe")
+  .version("0.2.0")
+  .description("UniPipe CLI - supercharge your GitOps OSB service pipelines");
 
+program
+  .command("completions", new CompletionsCommand());
+  
 // transform
-program
-  .command(
-    "transform <repo>",
-  )
-  .description(
-    "Transform service instances stored in a UniPipe OSB git repo using the specified handlers.",
-  )
-  .option(
-    "-h --handlers <handler.js/.ts file>",
-    "A registry of handlers for processing service instance transformation. These can be defined in either javascript or typescript as a JSON object with service ids as keys and handler objects as values. Note: typescript registries are not supported in single-binary builds of unipipe-cli.",
-  )
-  .option(
-    "-x --xport-repo [path]",
-    "Path to the target git repository. If not specified the transform runs in place on the OSB git repo.",
-  )
-  .action(async (repo: string, options: any) => {
-    const opts: TransformOpts = {
-      osbRepoPath: repo,
-      outRepoPath: options.xportRepo || repo,
-      handlers: options.handlers,
-    };
 
-    await transform(opts);
-  });
+registerListCmd(program);
+registerShowCmd(program);
+registerTransformCmd(program);
+registerUpdateCmd(program);
 
-// list
-program
-  .command("list <repo>")
-  .option(
-    "-p --profile [profile]",
-    "include columns of context information according to the specified OSB API profile. Supported values are 'meshmarketplace' and 'cloudfoundry'. Ignored when '-o json' is set.",
-  )
-  .option(
-    "-o --output-format [output-format]",
-    "Output format. Supported formats are json and text.",
-    (x) => x,
-    "text",
-  )
-  .description(
-    "Lists service instances status stored in a UniPipe OSB git repo.",
-  )
-  .action(async (repo: string, options: any) => {
-    const opts: ListOpts = {
-      osbRepoPath: repo,
-      profile: options.profile,
-      format: options.outputFormat,
-    };
-
-    await list(opts);
-  });
-
-// show
-program
-  .command("show <repo>")
-  .description(
-    "Shows the state stored service instance stored in a UniPipe OSB git repo.",
-  )
-  .option(
-    "-i --instance-id <instance-id>",
-    "Service instance id.",
-  )
-  .option(
-    "-o --output-format <output-format>",
-    "Output format. Supported formats are yaml and json.",
-  )
-  .option(
-    "--pretty",
-    "Pretty print",
-  )
-  .action(async (repo: string, options: any) => {
-    const opts: ShowOpts = {
-      osbRepoPath: repo,
-      instanceId: options.instanceId,
-      outputFormat: options.outputFormat,
-      pretty: options.pretty,
-    };
-
-    await show(opts);
-  });
-
-// update
-program
-  .command("update <repo>")
-  .description(
-    "update status of a service instance stored in a UniPipe OSB git repo.",
-  )
-  .option(
-    "-i --instance-id <instance-id>",
-    "Service instance id.",
-  )
-  .option(
-    "--status <status>",
-    "The status. Allowed values are 'in progress', 'succeeded' and 'failed'.",
-  ) // todo use choices instead
-  .option(
-    "--description [description]",
-    "Service Instance status description text.",
-  )
-  .action(async (repo: string, options: Record<string, any>) => {
-    const opts: UpdateOpts = {
-      osbRepoPath: repo,
-      instanceId: options.instanceId,
-      status: options.status,
-      description: options.description || "",
-    };
-
-    await update(opts);
-  });
-
-await program.parseAsync(Deno.args);
+await program.parse(Deno.args);

--- a/unipipe/osb.ts
+++ b/unipipe/osb.ts
@@ -1,4 +1,12 @@
+import { MeshMarketplaceContext } from './mesh.ts';
 import { parse } from './yaml.ts';
+
+export interface CloudFoundryContext {
+  // cloudfoundry context object, https://github.com/openservicebrokerapi/servicebroker/blob/master/profile.md#cloud-foundry-context-object  
+  platform: "cloudfoundry";
+  organization_name: string;
+  space_name: string;
+}
 
 export interface OsbServiceInstance {
   serviceInstanceId: string;
@@ -8,7 +16,7 @@ export interface OsbServiceInstance {
   // todo: technically we know a bit better
   originatingIdentity: Record<string, unknown>;
   parameters: Record<string, unknown>;
-  context: Record<string, unknown>;
+  context: MeshMarketplaceContext | CloudFoundryContext;
 
   serviceDefinition: {
     id: string;


### PR DESCRIPTION
This is the 3rd CLI lib/fx tried on unipipe-cli, hopefully working out
better this time. Reasons

- allows more strict parsing, esp. for enums
- deno-native (compared to commander.js ports with incomplete type defs)
- offers interesting features (colors, completions)
- very actively developed