### PR TITLE
fix(transform) rename -h/--handler option to -r/--registry-of-handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ interface File {
 
 Alternatively you can of course implement your own logic to write directories, call HTTP APIs etc. using the standard Deno APIs.
 
- Here's a full example for a `handlers.js` file that you can pass to `unipipe transform --handlers` and that writes service instance parameters into a custom directory structure:
+ Here's a full example for a `handlers.js` file that you can pass to `unipipe transform --registry-of-handlers` and that writes service instance parameters into a custom directory structure:
 
 ```text
   /tmp/git-tests.oFi6F1/git-tests.WgUs9M/repo.fp5ZEK

--- a/test/transform.sh
+++ b/test/transform.sh
@@ -12,7 +12,7 @@ it_can_transform_using_js() {
   local repo_osb=$(init_repo_osb)
   local repo_tf=$(init_repo)
 
-  unipipe transform --handlers "$handlers_js" --xport-repo "$repo_tf" "$repo_osb"
+  unipipe transform --registry-of-handlers "$handlers_js" --xport-repo "$repo_tf" "$repo_osb"
 
   echo "Output repo TF"
   tree "$repo_tf"
@@ -31,7 +31,7 @@ it_can_transform_using_ts() {
   local repo_osb=$(init_repo_osb)
   local repo_tf=$(init_repo)
 
-  unipipe transform --handlers "$handlers_ts" --xport-repo "$repo_tf" "$repo_osb"
+  unipipe transform --registry-of-handlers "$handlers_ts" --xport-repo "$repo_tf" "$repo_osb"
 
   echo "Output repo TF"
   tree "$repo_tf"

--- a/unipipe/blueprints/handler.js.js
+++ b/unipipe/blueprints/handler.js.js
@@ -1,6 +1,6 @@
 export const transformHandler = `
 /**
- Here's a full example for a handlers.js file that you can pass to unipipe transform --handlers and that writes service instance parameters into a custom directory structure:
+ Here's a full example for a handlers.js file that you can pass to unipipe transform --registry-of-handlers and that writes service instance parameters into a custom directory structure:
 
   /
   \`-- customers

--- a/unipipe/commands/transform.ts
+++ b/unipipe/commands/transform.ts
@@ -6,7 +6,7 @@ import { mapInstances } from './helpers.ts';
 
 interface TransformOpts {
   xportRepo: string;
-  handlers: string;
+  registryOfHandlers: string;
 }
 
 export function registerTransformCmd(program: Command) {
@@ -18,7 +18,7 @@ export function registerTransformCmd(program: Command) {
       "Transform service instances stored in a UniPipe OSB git repo using the specified handlers.",
     )
     .option(
-      "-h, --handlers <file>",
+      "-r, --registry-of-handlers <file>",
       "A registry of handlers for processing service instance transformation. These can be defined in either javascript or typescript as a JSON object with service ids as keys and handler objects as values. Note: typescript registries are not supported in single-binary builds of unipipe-cli.",
     )
     .option(
@@ -34,7 +34,7 @@ async function transform(
   osbRepoPath: string,
   opts: TransformOpts,
 ) {
-  const handlers = await loadHandlers(opts.handlers);
+  const handlers = await loadHandlers(opts.registryOfHandlers);
   const outRepoPath = opts.xportRepo || osbRepoPath;
 
   mapInstances(osbRepoPath, async (instance: ServiceInstance) => {


### PR DESCRIPTION
to avoid collision with -h/--help

This closes #10 