### PR TITLE
chore(cli): change generate unipipe-deployment subcommand

### DIFF
--- a/unipipe/commands/generate.ts
+++ b/unipipe/commands/generate.ts
@@ -23,7 +23,7 @@ export function registerGenerateCmd(program: Command) {
     )
     .action(() => generateTransformHandler())
     //
-    .command("unipipe-deployment")
+    .command("unipipe-service-broker-deployment")
     .description(
       "Generate infrastructure-as-code deployments for the UniPipe Service broker.",
     )


### PR DESCRIPTION
as unipipe-service-broker-deployment

We've discussed this on the #meshDelivery channel. The command will be more clear with this naming.